### PR TITLE
Change notifications link

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -93,7 +93,7 @@ export default {
 			return this.initialState?.url?.replace(/\/+$/, '')
 		},
 		showMoreUrl() {
-			return this.mastodonUrl + '/web/notifications'
+			return this.mastodonUrl + '/notifications'
 		},
 		items() {
 			return this.notifications.map((n) => {


### PR DESCRIPTION
This changes the "More Mastodon notifications" button so that it links to "/notifications" instead of "/web/notifications" (which creates a 404.