### PR TITLE
Prepare release v3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 3.2.1 - 2025-09-01
+
+### Changed
+
+- Keep NC 31 as max supported NC version for integration_mastodon v3.x.x
+
+### Fixed
+
+- Do not use `OCP\Search\IExternalProvider` before 32
+
 ## 3.2.0 - 2025-08-28
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>Mastodon integration</name>
 	<summary>Integration of Mastodon self-hosted social networking service</summary>
 	<description><![CDATA[Mastodon integration provides dashboard widgets displaying your important notifications and your home timeline. You can also post a public sharing link on your Mastodon profile.]]></description>
-	<version>3.2.0</version>
+	<version>3.2.1</version>
 	<licence>agpl</licence>
 	<author>Julien Veyssier</author>
 	<namespace>Mastodon</namespace>
@@ -17,7 +17,7 @@
 	<bugs>https://github.com/nextcloud/integration_mastodon/issues</bugs>
 	<screenshot>https://github.com/nextcloud/integration_mastodon/raw/main/img/screenshot1.jpg</screenshot>
 	<dependencies>
-		<nextcloud min-version="27" max-version="32"/>
+		<nextcloud min-version="27" max-version="31"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\Mastodon\Settings\Admin</admin>

--- a/lib/Search/SearchAccountsProvider.php
+++ b/lib/Search/SearchAccountsProvider.php
@@ -32,13 +32,12 @@ use OCP\IConfig;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\Search\IProvider;
-use OCP\Search\IExternalProvider;
 use OCP\Search\ISearchQuery;
 use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
 
 
-class SearchAccountsProvider implements IProvider, IExternalProvider {
+class SearchAccountsProvider implements IProvider {
 
 	public function __construct(
 		private IAppManager $appManager,
@@ -148,8 +147,5 @@ class SearchAccountsProvider implements IProvider, IExternalProvider {
 			['imageUrl' => $entry['avatar']]
 		);
 		return [true, $url];
-	}
-	public function isExternalProvider(): bool {
-		return true;
 	}
 }

--- a/lib/Search/SearchHashtagsProvider.php
+++ b/lib/Search/SearchHashtagsProvider.php
@@ -31,13 +31,12 @@ use OCP\IL10N;
 use OCP\IConfig;
 use OCP\IURLGenerator;
 use OCP\IUser;
-use OCP\Search\IExternalProvider;
 use OCP\Search\IProvider;
 use OCP\Search\ISearchQuery;
 use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
 
-class SearchHashtagsProvider implements IProvider, IExternalProvider {
+class SearchHashtagsProvider implements IProvider {
 
 	public function __construct(
 		private IAppManager $appManager,
@@ -142,7 +141,4 @@ class SearchHashtagsProvider implements IProvider, IExternalProvider {
 		return [true, $url];
 	}
 
-	public function isExternalProvider(): bool {
-		return true;
-	}
 }

--- a/lib/Search/SearchStatusesProvider.php
+++ b/lib/Search/SearchStatusesProvider.php
@@ -32,13 +32,12 @@ use OCP\IL10N;
 use OCP\IConfig;
 use OCP\IURLGenerator;
 use OCP\IUser;
-use OCP\Search\IExternalProvider;
 use OCP\Search\IProvider;
 use OCP\Search\ISearchQuery;
 use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
 
-class SearchStatusesProvider implements IProvider, IExternalProvider {
+class SearchStatusesProvider implements IProvider {
 
 	public function __construct(
 		private IAppManager $appManager,
@@ -154,9 +153,5 @@ class SearchStatusesProvider implements IProvider, IExternalProvider {
 			['imageUrl' => $entry['account']['avatar']]
 		);
 		return [true, $url];
-	}
-
-	public function isExternalProvider(): bool {
-		return true;
 	}
 }


### PR DESCRIPTION
### Changed

- Keep NC 31 as max supported NC version for integration_mastodon v3.x.x

### Fixed

- Do not use `OCP\Search\IExternalProvider` before 32